### PR TITLE
Merge upstream security fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,6 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore
-/error_reporting.ini export-ignore
 /make-release.sh export-ignore
 /phpunit.sh export-ignore
 /phpunit.xml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,39 @@
 language: php
+os: linux
+dist: xenial
 
-sudo: false
+install:
+  - travis_retry composer install
 
-dist: trusty
-
-matrix:
+jobs:
   include:
-   - php: 5.3 # Composer requires PHP 5.3.2+ to run, so we cannot test below 5.3
+   - php: 5.3 # Composer and PHPUnit require PHP 5.3.2+ to run, so we cannot test below 5.3
      dist: precise # PHP 5.3 is supported only on Precise.
    - php: 5.4
+     dist: trusty  # PHP 5.4 is supported only on Trusty.
    - php: 5.5
+     dist: trusty  # PHP 5.5 is supported only on Trusty.
    - php: 5.6
    - php: 7.0
    - php: 7.1
    - php: 7.2
    - php: 7.3
    - php: 7.4
-#   - php: nightly # PHP nightly build testing disabled because PHPUnit doesn't support PHP8 yet.
+   - php: nightly
+     install: travis_retry composer config platform.php 7.4.0 && composer install
   fast_finish: true
   allow_failures:
-   - php: nightly
+   - php: nightly # PHP 8 is still in beta
 
 services:
   - memcached
   - mysql
 
 before_script:
-    - mysql -e "create database IF NOT EXISTS test;" -uroot
+  - mysql -e "create database IF NOT EXISTS test;" -uroot
 
 before_install:
-    - phpenv config-rm xdebug.ini || return 0
-
-install:
-    - travis_retry composer install
+  - phpenv config-rm xdebug.ini || return 0
 
 script:
-   - ./phpunit.sh
+  - ./phpunit.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- modifier escape now triggers a E_USER_NOTICE when an unsupported escape type is used https://github.com/smarty-php/smarty/pull/649
+
 ## [3.1.39] - 2021-02-17
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
-- Prevent access to `$smarty.template_object` in Security mode
-- Code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 
+- Prevent access to `$smarty.template_object` in sandbox mode
+- Fixed code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 
 
 ## [3.1.38] - 2021-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Travis unit tests now run for all php versions >= 5.3
+- Changed error handlers and handling of undefined constants for php8-compatibility (set $errcontext argument optional) https://github.com/smarty-php/smarty/issues/605
+- Changed expected error levels in unit tests for php8-compatibility
+- Travis unit tests now run for all php versions >= 5.3, including php8
+- Travis runs on Xenial where possible
 
 ### Fixed
-- PHP5.3 compatability fixes
+- PHP5.3 compatibility fixes
 
 ## [3.1.36] - 2020-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.37] - 2021-01-07
+
 ### Changed
 - Changed error handlers and handling of undefined constants for php8-compatibility (set $errcontext argument optional) https://github.com/smarty-php/smarty/issues/605
 - Changed expected error levels in unit tests for php8-compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - PHP5.3 compatibility fixes
+- Brought lexer source functionally up-to-date with compiled version
 
 ## [3.1.36] - 2020-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.38] - 2021-01-08
+
 ### Fixed
 - Smarty::SMARTY_VERSION wasn't updated https://github.com/smarty-php/smarty/issues/628
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Prevent access to `$smarty.template_object` in Security mode
+
 ## [3.1.38] - 2021-01-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Smarty::SMARTY_VERSION wasn't updated https://github.com/smarty-php/smarty/issues/628
+
 ## [3.1.37] - 2021-01-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.39] - 2021-02-17
+
 ### Security
 - Prevent access to `$smarty.template_object` in sandbox mode
 - Fixed code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 
+
 ## [3.1.38] - 2021-01-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Security
 - Prevent access to `$smarty.template_object` in Security mode
 
 ## [3.1.38] - 2021-01-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.1.39] - 2021-02-17
 
 ### Security
-- Prevent access to `$smarty.template_object` in sandbox mode
-- Fixed code injection vulnerability by using illegal function names in `{function name='blah'}{/function}` 
+- Prevent access to `$smarty.template_object` in sandbox mode. This addresses CVE-2021-26119.
+- Fixed code injection vulnerability by using illegal function names in `{function name='blah'}{/function}`. This addresses CVE-2021-26120.
 
 ## [3.1.38] - 2021-01-08
 

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Smarty: the PHP compiling template engine
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
- version 2.1 of the License, or (at your option) any later version.
+ version 3.0 of the License, or (at your option) any later version.
 
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Smarty currently supports the latest minor version of Smarty 3 and Smarty 4. (Smarty 4 has not been released yet.)
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 4.0.x   | :white_check_mark: |
+| 3.1.x   | :white_check_mark: |
+| < 3.1   | :x:                |
+
+## Reporting a Vulnerability
+
+ If you have discovered a security issue with Smarty, please contact us at mail [at] simonwisselink.nl. Do not 
+ disclose your findings publicly and PLEASE PLEASE do not file an Issue.
+ 
+We will try to confirm the vulnerability and develop a fix if appropriate. When we release the fix, we will publish 
+a security release. Please let us know if you want to be credited.

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "6.4.1 || ^5.7 || ^4.8",
+        "phpunit/phpunit": "^7.5 || ^6.5 || ^5.7 || ^4.8",
         "smarty/smarty-lexer": "^3.1"
     }
 }

--- a/error_reporting.ini
+++ b/error_reporting.ini
@@ -1,1 +1,0 @@
-error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT

--- a/lexer/smarty_internal_templateparser.y
+++ b/lexer/smarty_internal_templateparser.y
@@ -249,7 +249,13 @@ template       ::= template PHP(B). {
 
                       // template text
 template       ::= template  TEXT(B). {
-         $this->current_buffer->append_subtree($this, $this->compiler->processText(B));
+         $text = $this->yystack[ $this->yyidx + 0 ]->minor;
+
+         if ((string)$text == '') {
+            $this->current_buffer->append_subtree($this, null);
+         }
+
+         $this->current_buffer->append_subtree($this, new Smarty_Internal_ParseTree_Text($text, $this->strip));
 }
                       // strip on
 template       ::= template  STRIPON. {
@@ -308,7 +314,7 @@ smartytag(A)::= SIMPLETAG(B). {
     $tag = trim(substr(B, $this->compiler->getLdelLength(), -$this->compiler->getRdelLength()));
     if ($tag == 'strip') {
         $this->strip = true;
-        A = null;;
+        A = null;
     } else {
         if (defined($tag)) {
             if ($this->security) {

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -111,7 +111,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     /**
      * smarty version
      */
-    const SMARTY_VERSION = '3.1.38';
+    const SMARTY_VERSION = '3.1.39';
     /**
      * define variable scopes
      */

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -27,7 +27,7 @@
  * @author    Uwe Tews   <uwe dot tews at gmail dot com>
  * @author    Rodney Rehm
  * @package   Smarty
- * @version   3.1.34-dev
+ * @version   3.1.36
  */
 /**
  * set SMARTY_DIR to absolute path to Smarty library files.

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -6,7 +6,7 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * version 3.0 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -111,7 +111,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     /**
      * smarty version
      */
-    const SMARTY_VERSION = '3.1.37';
+    const SMARTY_VERSION = '3.1.38';
     /**
      * define variable scopes
      */

--- a/libs/Smarty.class.php
+++ b/libs/Smarty.class.php
@@ -27,7 +27,6 @@
  * @author    Uwe Tews   <uwe dot tews at gmail dot com>
  * @author    Rodney Rehm
  * @package   Smarty
- * @version   3.1.36
  */
 /**
  * set SMARTY_DIR to absolute path to Smarty library files.
@@ -112,7 +111,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     /**
      * smarty version
      */
-    const SMARTY_VERSION = '3.1.36';
+    const SMARTY_VERSION = '3.1.37';
     /**
      * define variable scopes
      */

--- a/libs/SmartyBC.class.php
+++ b/libs/SmartyBC.class.php
@@ -6,7 +6,7 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * version 3.0 of the License, or (at your option) any later version.
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU

--- a/libs/plugins/modifier.escape.php
+++ b/libs/plugins/modifier.escape.php
@@ -250,6 +250,7 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
             }
             return $return;
         default:
+            trigger_error("escape: unsupported type: $esc_type - returning unmodified string", E_USER_NOTICE);
             return $string;
     }
 }

--- a/libs/sysplugins/smarty_internal_compile_function.php
+++ b/libs/sysplugins/smarty_internal_compile_function.php
@@ -58,6 +58,11 @@ class Smarty_Internal_Compile_Function extends Smarty_Internal_CompileBase
         }
         unset($_attr[ 'nocache' ]);
         $_name = trim($_attr[ 'name' ], '\'"');
+
+        if (!preg_match('/^[a-zA-Z0-9_\x80-\xff]+$/', $_name)) {
+	        $compiler->trigger_template_error("Function name contains invalid characters: {$_name}", null, true);
+        }
+
         $compiler->parent_compiler->tpl_function[ $_name ] = array();
         $save = array(
             $_attr, $compiler->parser->current_buffer, $compiler->template->compiled->has_nocache_code,

--- a/libs/sysplugins/smarty_internal_compile_private_special_variable.php
+++ b/libs/sysplugins/smarty_internal_compile_private_special_variable.php
@@ -81,6 +81,10 @@ class Smarty_Internal_Compile_Private_Special_Variable extends Smarty_Internal_C
                 case 'template':
                     return 'basename($_smarty_tpl->source->filepath)';
                 case 'template_object':
+                    if (isset($compiler->smarty->security_policy)) {
+                        $compiler->trigger_template_error("(secure mode) template_object not permitted");
+                        break;
+                    }
                     return '$_smarty_tpl';
                 case 'current_dir':
                     return 'dirname($_smarty_tpl->source->filepath)';

--- a/libs/sysplugins/smarty_internal_compile_private_special_variable.php
+++ b/libs/sysplugins/smarty_internal_compile_private_special_variable.php
@@ -94,9 +94,9 @@ class Smarty_Internal_Compile_Private_Special_Variable extends Smarty_Internal_C
                         break;
                     }
                     if (strpos($_index[ 1 ], '$') === false && strpos($_index[ 1 ], '\'') === false) {
-                        return "@constant('{$_index[1]}')";
+                        return "defined('{$_index[1]}') ? constant('{$_index[1]}') : null";
                     } else {
-                        return "@constant({$_index[1]})";
+                        return "defined({$_index[1]}) ? constant({$_index[1]}) : null";
                     }
                 // no break
                 case 'config':

--- a/libs/sysplugins/smarty_internal_compile_private_special_variable.php
+++ b/libs/sysplugins/smarty_internal_compile_private_special_variable.php
@@ -94,9 +94,9 @@ class Smarty_Internal_Compile_Private_Special_Variable extends Smarty_Internal_C
                         break;
                     }
                     if (strpos($_index[ 1 ], '$') === false && strpos($_index[ 1 ], '\'') === false) {
-                        return "defined('{$_index[1]}') ? constant('{$_index[1]}') : null";
+                        return "(defined('{$_index[1]}') ? constant('{$_index[1]}') : null)";
                     } else {
-                        return "defined({$_index[1]}) ? constant({$_index[1]}) : null";
+                        return "(defined({$_index[1]}) ? constant({$_index[1]}) : null)";
                     }
                 // no break
                 case 'config':

--- a/libs/sysplugins/smarty_internal_config_file_compiler.php
+++ b/libs/sysplugins/smarty_internal_config_file_compiler.php
@@ -115,7 +115,7 @@ class Smarty_Internal_Config_File_Compiler
             $this->smarty->_debug->start_compile($this->template);
         }
         // init the lexer/parser to compile the config file
-        /* @var Smarty_Internal_ConfigFileLexer $this ->lex */
+        /* @var Smarty_Internal_ConfigFileLexer $this->lex */
         $this->lex = new $this->lexer_class(
             str_replace(
                 array(
@@ -127,7 +127,7 @@ class Smarty_Internal_Config_File_Compiler
             ) . "\n",
             $this
         );
-        /* @var Smarty_Internal_ConfigFileParser $this ->parser */
+        /* @var Smarty_Internal_ConfigFileParser $this->parser */
         $this->parser = new $this->parser_class($this->lex, $this);
         if (function_exists('mb_internal_encoding')
             && function_exists('ini_get')

--- a/libs/sysplugins/smarty_internal_errorhandler.php
+++ b/libs/sysplugins/smarty_internal_errorhandler.php
@@ -65,7 +65,7 @@ class Smarty_Internal_ErrorHandler
      *
      * @return bool
      */
-    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext)
+    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext = array())
     {
         $_is_muted_directory = false;
         // add the SMARTY_DIR to the list of muted directories

--- a/make-release.sh
+++ b/make-release.sh
@@ -14,6 +14,6 @@ git pull
 git merge --no-ff "release/$1"
 git branch -d "release/$1"
 git tag -a "v$1" -m "Release $1"
-git push --follow-tags
 
 printf 'Done creating release %s\n' "$1"
+printf 'Run `git push --follow-tags origin` to publish it.\n'

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -16,7 +16,6 @@ if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Frame
     class_alias('\PHPUnit\Framework\Error\Error', '\PHPUnit_Framework_Error_Error');
     class_alias('\PHPUnit\Framework\Error\Warning', '\PHPUnit_Framework_Error_Warning');
     class_alias('\PHPUnit\Framework\Error\Warning', '\PHPUnit_Framework_Error_Deprecated');
-    class_alias('\PHPUnit\Util\Configuration', '\PHPUnit_Util_Configuration');
 }
 
 require_once 'PHPUnit_Smarty.php';

--- a/tests/UnitTests/A_2/UndefinedTemplateVar/UndefinedTemplateVarTest.php
+++ b/tests/UnitTests/A_2/UndefinedTemplateVar/UndefinedTemplateVarTest.php
@@ -24,34 +24,37 @@ class UndefinedTemplateVarTest extends PHPUnit_Smarty
         $this->cleanDirs();
     }
     /**
-     * Test E_NOTICE suppression template fetched by Smarty object
+     * Test Error suppression template fetched by Smarty object
      */
-    public function testE_NoticeDisabled()
+    public function testErrorDisabled()
     {
         $e1 = error_reporting();
-        $this->smarty->setErrorReporting(E_ALL & ~E_NOTICE);
+        $this->smarty->setErrorReporting(E_ALL & ~E_WARNING & ~E_NOTICE);
         $this->assertEquals('undefined = ', $this->smarty->fetch('001_main.tpl'));
         $e2 = error_reporting();
         $this->assertEquals($e1, $e2);
     }
 
     /**
-     * Test E_NOTICE suppression template fetched by template object
+     * Test Error suppression template fetched by template object
      */
-    public function testE_NoticeDisabledTplObject_1()
+    public function testErrorDisabledTplObject_1()
     {
         $e1 = error_reporting();
-        $this->smarty->setErrorReporting(E_ALL & ~E_NOTICE);
+        $this->smarty->setErrorReporting(E_ALL & ~E_WARNING & ~E_NOTICE);
         $tpl = $this->smarty->createTemplate('001_main.tpl');
         $this->assertEquals('undefined = ', $tpl->fetch());
         $e2 = error_reporting();
         $this->assertEquals($e1, $e2);
     }
 
-    public function testE_NoticeDisabledTplObject_2()
+	/**
+	 * Test Error suppression template object fetched by Smarty object
+	 */
+    public function testErrorDisabledTplObject_2()
     {
         $e1 = error_reporting();
-        $this->smarty->setErrorReporting(E_ALL & ~E_NOTICE);
+        $this->smarty->setErrorReporting(E_ALL & ~E_WARNING & ~E_NOTICE);
         $tpl = $this->smarty->createTemplate('001_main.tpl');
         $this->assertEquals('undefined = ', $this->smarty->fetch($tpl));
         $e2 = error_reporting();
@@ -59,16 +62,31 @@ class UndefinedTemplateVarTest extends PHPUnit_Smarty
     }
 
     /**
-     * Throw E_NOTICE message
-     *
-     * @expectedException PHPUnit_Framework_Error_Notice
-     * @expectedExceptionMessage Undefined index: foo
+     * Throw Error message
      */
-    public function testE_Notice()
+    public function testError()
     {
-            $e1 = error_reporting();
-            $this->assertEquals('undefined = ', $this->smarty->fetch('001_main.tpl'));
-            $e2 = error_reporting();
-            $this->assertEquals($e1, $e2);
+	    $exceptionThrown = false;
+
+        try {
+	        $e1 = error_reporting();
+	        $this->assertEquals('undefined = ', $this->smarty->fetch('001_main.tpl'));
+	        $e2 = error_reporting();
+	        $this->assertEquals($e1, $e2);
+        } catch (Exception $e) {
+
+        	$exceptionThrown = true;
+	        $this->assertStringStartsWith('Undefined ', $e->getMessage());
+	        $this->assertTrue(in_array(
+	        	get_class($e),
+		        array(
+		        	'PHPUnit_Framework_Error_Warning',
+			        'PHPUnit_Framework_Error_Notice',
+			        'PHPUnit\Framework\Error\Warning',
+			        'PHPUnit\Framework\Error\Notice',
+		        )
+	        ));
+        }
+	    $this->assertTrue($exceptionThrown);
     }
 }

--- a/tests/UnitTests/A_Core/MuteExpectedErrors/MuteExpectedErrorsTest.php
+++ b/tests/UnitTests/A_Core/MuteExpectedErrors/MuteExpectedErrorsTest.php
@@ -27,7 +27,7 @@ class MuteExpectedErrorsTest extends PHPUnit_Smarty
     {
         $this->cleanDirs();
     }
-    public function error_handler($errno, $errstr, $errfile, $errline, $errcontext)
+    public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = array())
     {
         $this->_errors[] = $errfile . ' line ' . $errline;
     }

--- a/tests/UnitTests/CacheResourceTests/_shared/CacheResourceTestCommon.php
+++ b/tests/UnitTests/CacheResourceTests/_shared/CacheResourceTestCommon.php
@@ -339,6 +339,10 @@ class CacheResourceTestCommon extends PHPUnit_Smarty
         $this->assertNull($tpl->cached->handler->getCachedContent($tpl3));
         $this->assertEquals('hello world', $tpl->cached->handler->getCachedContent($tpl4));
     }
+
+    /**
+     * @group slow
+     */
    public function testClearCacheExpired()
     {
         $this->smarty->caching = true;
@@ -399,7 +403,7 @@ class CacheResourceTestCommon extends PHPUnit_Smarty
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      * @dataProvider data
-     *
+     * @group slow
      */
     public function testCache($lockTime, $lockTimeout, $compile_id, $cache_id, $isCached, $tmin, $tmax, $forceCompile, $forceCache, $update, $testNumber, $compileTestNumber, $renderTestNumber, $testName)
     {

--- a/tests/UnitTests/ConfigFileTests/file/ConfigVarTest.php
+++ b/tests/UnitTests/ConfigFileTests/file/ConfigVarTest.php
@@ -403,7 +403,11 @@ class ConfigVarTest extends PHPUnit_Smarty
             $this->assertEquals("", $this->smarty->fetch('foo.tpl'));
         }
         catch (Exception $e) {
-            $this->assertEquals('Undefined variable: foo', $e->getMessage());
+	        if (PHP_VERSION_ID >= 80000) {
+		        $this->assertStringStartsWith('Undefined variable', $e->getMessage());
+	        } else {
+		        $this->assertStringStartsWith('Undefined variable', $e->getMessage());
+	        }
         }
     }
 }

--- a/tests/UnitTests/ResourceTests/Extends/ExtendsResourceTest.php
+++ b/tests/UnitTests/ResourceTests/Extends/ExtendsResourceTest.php
@@ -125,7 +125,7 @@ class ExtendsResourceTest extends PHPUnit_Smarty
      * test  grandchild/child/parent dependency test2
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     *
+     * @group slow
      */
     public function testCompileBlockGrandChildMustCompile_021_2()
     {
@@ -193,7 +193,7 @@ class ExtendsResourceTest extends PHPUnit_Smarty
      * test  grandchild/child/parent dependency test4
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     *
+     * @group slow
      */
     public function testCompileBlockGrandChildMustCompile_021_4()
     {

--- a/tests/UnitTests/SecurityTests/SecurityTest.php
+++ b/tests/UnitTests/SecurityTests/SecurityTest.php
@@ -385,10 +385,10 @@ class SecurityTest extends PHPUnit_Smarty
 
     /**
      * In security mode, accessing $smarty.template_object should be illegal.
+     * @expectedException SmartyCompilerException
      */
     public function testSmartyTemplateObject() {
-    	$this->expectException(SmartyCompilerException::class);
-	    $this->smarty->display('string:{$smarty.template_object}');
+        $this->smarty->display('string:{$smarty.template_object}');
     }
 
 }

--- a/tests/UnitTests/SecurityTests/SecurityTest.php
+++ b/tests/UnitTests/SecurityTests/SecurityTest.php
@@ -382,6 +382,15 @@ class SecurityTest extends PHPUnit_Smarty
         $this->smarty->security_policy->trusted_uri = array();
         $this->assertContains('<title>Preface | Smarty</title>', $this->smarty->fetch('string:{fetch file="https://www.smarty.net/docs/en/preface.tpl"}'));
     }
+
+    /**
+     * In security mode, accessing $smarty.template_object should be illegal.
+     */
+    public function testSmartyTemplateObject() {
+    	$this->expectException(SmartyCompilerException::class);
+	    $this->smarty->display('string:{$smarty.template_object}');
+    }
+
 }
 
 class mysecuritystaticclass

--- a/tests/UnitTests/SmartyMethodsTests/ClearAllAssign/ClearAllAssignBCTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/ClearAllAssign/ClearAllAssignBCTest.php
@@ -33,7 +33,7 @@ class ClearAllAssignBCTest extends PHPUnit_Smarty
 
     public function testSmarty2ClearAllAssignInSmarty()
     {
-        error_reporting((error_reporting() & ~(E_NOTICE | E_USER_NOTICE)));
+        error_reporting((error_reporting() & ~(E_NOTICE | E_WARNING | E_USER_NOTICE)));
         $this->smartyBC->clear_all_assign();
         $this->assertEquals('barblar', $this->smartyBC->fetch($this->_tplBC));
     }

--- a/tests/UnitTests/SmartyMethodsTests/ClearAllAssign/ClearAllAssignTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/ClearAllAssign/ClearAllAssignTest.php
@@ -46,7 +46,7 @@ class ClearAllAssignTest extends PHPUnit_Smarty
      */
     public function testClearAllAssignInTemplate()
     {
-        error_reporting((error_reporting() & ~(E_NOTICE | E_USER_NOTICE)));
+        error_reporting((error_reporting() & ~(E_NOTICE | E_USER_NOTICE | E_WARNING)));
         $this->_tpl->clearAllAssign();
         $this->assertEquals('foobar', $this->smarty->fetch($this->_tpl));
     }
@@ -56,7 +56,7 @@ class ClearAllAssignTest extends PHPUnit_Smarty
      */
     public function testClearAllAssignInData()
     {
-        error_reporting((error_reporting() & ~(E_NOTICE | E_USER_NOTICE)));
+        error_reporting((error_reporting() & ~(E_NOTICE | E_USER_NOTICE | E_WARNING)));
         $this->_data->clearAllAssign();
         $this->assertEquals('fooblar', $this->smarty->fetch($this->_tpl));
     }
@@ -66,7 +66,7 @@ class ClearAllAssignTest extends PHPUnit_Smarty
      */
     public function testClearAllAssignInSmarty()
     {
-        error_reporting((error_reporting() & ~(E_NOTICE | E_USER_NOTICE)));
+        error_reporting((error_reporting() & ~(E_NOTICE | E_USER_NOTICE | E_WARNING)));
         $this->smarty->clearAllAssign();
         $this->assertEquals('barblar', $this->smarty->fetch($this->_tpl));
     }

--- a/tests/UnitTests/SmartyMethodsTests/ClearAssign/ClearAssignBCTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/ClearAssign/ClearAssignBCTest.php
@@ -33,14 +33,14 @@ class ClearAssignBCTest extends PHPUnit_Smarty
     }
     public function testSmarty2ClearAssign()
     {
-        $this->smartyBC->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE));
+        $this->smartyBC->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE | E_WARNING));
         $this->smartyBC->clear_assign('blar');
         $this->assertEquals('foobar', $this->smartyBC->fetch('eval:{$foo}{$bar}{$blar}'));
     }
 
     public function testSmarty2ArrayClearAssign()
     {
-        $this->smartyBC->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE));
+        $this->smartyBC->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE | E_WARNING));
         $this->smartyBC->clear_assign(array('blar', 'foo'));
         $this->assertEquals('bar', $this->smartyBC->fetch('eval:{$foo}{$bar}{$blar}'));
     }

--- a/tests/UnitTests/SmartyMethodsTests/ClearAssign/ClearAssignTest.php
+++ b/tests/UnitTests/SmartyMethodsTests/ClearAssign/ClearAssignTest.php
@@ -36,7 +36,7 @@ class ClearAssignTest extends PHPUnit_Smarty
      */
     public function testClearAssign()
     {
-        $this->smarty->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE));
+        $this->smarty->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE | E_WARNING));
         $this->smarty->clearAssign('blar');
         $this->assertEquals('foobar', $this->smarty->fetch('eval:{$foo}{$bar}{$blar}'));
     }
@@ -46,7 +46,7 @@ class ClearAssignTest extends PHPUnit_Smarty
      */
     public function testArrayClearAssign()
     {
-        $this->smarty->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE));
+        $this->smarty->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE | E_WARNING));
         $this->smarty->clearAssign(array('blar', 'foo'));
         $this->assertEquals('bar', $this->smarty->fetch('eval:{$foo}{$bar}{$blar}'));
     }

--- a/tests/UnitTests/TemplateSource/TagTests/BockExtend/CompileBlockExtendsTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/BockExtend/CompileBlockExtendsTest.php
@@ -610,7 +610,7 @@ class CompileBlockExtendsTest extends PHPUnit_Smarty
      *
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     *
+     * @group slow
      */
     public function testCompileBlockGrandChildMustCompile_021_2()
     {
@@ -645,7 +645,7 @@ class CompileBlockExtendsTest extends PHPUnit_Smarty
      *
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     *
+     * @group slow
      */
     public function testCompileBlockGrandChildMustCompile_021_3()
     {
@@ -670,7 +670,7 @@ class CompileBlockExtendsTest extends PHPUnit_Smarty
      *
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     *
+     * @group slow
      */
     public function testCompileBlockGrandChildMustCompile_021_32()
     {
@@ -692,6 +692,7 @@ class CompileBlockExtendsTest extends PHPUnit_Smarty
      *
      * @runInSeparateProcess
      * @preserveGlobalState disabled
+     * @group slow
      */
     public function testCompileBlockGrandChildMustCompile_021_4()
     {
@@ -716,6 +717,7 @@ class CompileBlockExtendsTest extends PHPUnit_Smarty
      *
      * @runInSeparateProcess
      * @preserveGlobalState disabled
+     * @group slow
      */
     public function testCompileBlockGrandChildMustCompile_021_42()
     {

--- a/tests/UnitTests/TemplateSource/TagTests/Foreach/CompileForeachTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Foreach/CompileForeachTest.php
@@ -44,7 +44,7 @@ class CompileForeachTest extends PHPUnit_Smarty
             $this->smarty->assign('foo', $foo);
         } else {
             // unassigned $from parameter
-            $this->smarty->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE));
+            $this->smarty->setErrorReporting(error_reporting() & ~(E_NOTICE | E_USER_NOTICE | E_WARNING));
         }
 
         $this->assertEquals($result, $this->smarty->fetch($file), "testForeach - {$code} - {$testName}");

--- a/tests/UnitTests/TemplateSource/TagTests/Insert/CompileInsertTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/Insert/CompileInsertTest.php
@@ -210,6 +210,7 @@ class CompileInsertTest extends PHPUnit_Smarty
      * test insert plugin caching 2
      * @runInSeparateProcess
      * @preserveGlobalState disabled
+     * @group slow
      */
     public function testInsertPluginCaching3_2()
     {

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlCheckboxesTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlCheckboxesTest.php
@@ -275,7 +275,7 @@ class PluginFunctionHtmlCheckboxesTest extends PHPUnit_Smarty
 
     protected $_errors = array();
 
-    public function error_handler($errno, $errstr, $errfile, $errline, $errcontext)
+    public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = array())
     {
         $this->_errors[] = $errstr;
     }

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlOptionsTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlOptionsTest.php
@@ -369,7 +369,7 @@ class PluginFunctionHtmlOptionsTest extends PHPUnit_Smarty
 
     protected $_errors = array();
 
-    public function error_handler($errno, $errstr, $errfile, $errline, $errcontext)
+    public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = array())
     {
         $this->_errors[] = $errstr;
     }

--- a/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlRadiosTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/PluginFunction/PluginFunctionHtmlRadiosTest.php
@@ -275,7 +275,7 @@ class PluginFunctionHtmlRadiosTest extends PHPUnit_Smarty
 
     protected $_errors = array();
 
-    public function error_handler($errno, $errstr, $errfile, $errline, $errcontext)
+    public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = array())
     {
         $this->_errors[] = $errstr;
     }

--- a/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
@@ -431,5 +431,14 @@ class CompileFunctionTest extends PHPUnit_Smarty
                      array("{function name=simple}A{\$foo}\nC{/function}{call name='simple'}", "Abar\nC", 'T14', $i++),
                      array("{function name=simple}A\n{\$foo}\nC{/function}{call name='simple'}", "A\nbar\nC", 'T15', $i++),
         );
-            }
+    }
+
+    /**
+     * Test handling of function names that are a security risk
+     */
+    public function testIllegalFunctionName() {
+	    $this->expectException(SmartyCompilerException::class);
+	    $this->smarty->fetch('string:{function name=\'rce(){};echo "hi";function \'}{/function}');
+    }
+
 }

--- a/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
@@ -435,9 +435,9 @@ class CompileFunctionTest extends PHPUnit_Smarty
 
     /**
      * Test handling of function names that are a security risk
+     * @expectedException        SmartyCompilerException
      */
     public function testIllegalFunctionName() {
-	    $this->expectException(SmartyCompilerException::class);
 	    $this->smarty->fetch('string:{function name=\'rce(){};echo "hi";function \'}{/function}');
     }
 

--- a/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
+++ b/tests/UnitTests/TemplateSource/TagTests/TemplateFunction/CompileFunctionTest.php
@@ -297,7 +297,7 @@ class CompileFunctionTest extends PHPUnit_Smarty
      */
     public function testExternalDefinedFunctionRecursion($text)
     {
-        $this->assertEquals('12345', $this->smarty->fetch('test_template_function_recursion2.tpl'), $text);
+        $this->assertEquals('012345', $this->smarty->fetch('test_template_function_recursion2.tpl'), $text);
     }
 
     /**

--- a/tests/UnitTests/TemplateSource/ValueTests/ConstantTests/ConstantsTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/ConstantTests/ConstantsTest.php
@@ -78,11 +78,13 @@ class ConstantsTest extends PHPUnit_Smarty
     }
     public function testConstantsUndefined()
     {
+	    $this->smarty->setErrorReporting(E_ALL & ~E_WARNING & ~E_NOTICE);
         $tpl = $this->smarty->createTemplate('string:{$smarty.const.MYCONSTANT2}');
         $this->assertEquals("", $this->smarty->fetch($tpl));
     }
     public function testConstantsUndefined2()
     {
+	    $this->smarty->setErrorReporting(E_ALL & ~E_WARNING & ~E_NOTICE);
         $tpl = $this->smarty->createTemplate('eval:{$foo = MYCONSTANT2}{$foo}');
         $this->assertEquals("MYCONSTANT2", $this->smarty->fetch($tpl));
     }

--- a/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Now/SmartyNowTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/SmartySpecialVars/Now/SmartyNowTest.php
@@ -35,7 +35,7 @@ class SmartyNowTest extends PHPUnit_Smarty
     }
     /**
      * test {$smarty.now nocache}
-     *
+     * @group slow
      */
     public function testSmartyNowNocache() {
         $this->smarty->setCaching(true);

--- a/tests/UnitTests/TemplateSource/ValueTests/Variables/Stream/StreamVariableTest.php
+++ b/tests/UnitTests/TemplateSource/ValueTests/Variables/Stream/StreamVariableTest.php
@@ -59,7 +59,7 @@ class StreamVariableTest extends PHPUnit_Smarty
         }
     */
     /**
-     * test no existant stream variable
+     * test no existent stream variable
      */
     //    public function testStreamVariable2()
     //    {


### PR DESCRIPTION
Related https://srcincite.io/blog/2021/02/18/smarty-template-engine-multiple-sandbox-escape-vulnerabilities.html

Pretty sure we already had those patched (it was disabling template security from within the template).

They also look like they have their own static class checks, but ours are stricter.